### PR TITLE
Updated FileInput to ignore "abortIf" input prop

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,6 +21,7 @@ const SUPPORTED_EVENTS = [
 
 const UNSUPPORTED_BY_INPUT = {
   readAs: true,
+  abortIf: true,
   cancelIf: true,
   onCancel: true
 };


### PR DESCRIPTION
The JS console in Chrome displays the following warning regarding the abortIf prop:
```
Warning: Unknown prop `abortIf` on <input> tag. Remove this prop from the element. For details, see https://fb.me/react-unknown-prop
    in FileInput (at index.js:30)
```
UNSUPPORTED_BY_INPUT needs to be updated to include the abortIf prop.