### PR TITLE
Added import PropTypes to support react version 15.5 and above.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
-import React, { PropTypes, Component } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 const INPUT_FIELD_REF = 'inputField';
 


### PR DESCRIPTION
Added import PropTypes from 'prop-types' to support react version 15.5 and above.
removed the PorpType from react lib and used the prop-types lib.