### PR TITLE
Extending React.Component to allow import

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,8 @@
 // Type definitions for React Simple File Input
 // Project: react-simple-file-input
 
+import React from "react";
+
 /**
  * Called after the user has finished selecting file(s) using the browser dialog.
  */
@@ -147,7 +149,7 @@ interface ComponentProps {
  * It supports all of the properties available to a file input field, and all of the
  * events supplied by a FileReader with a few additional ones as well.
  */
-export default class FileInput {
+export default class FileInput extends React.Component<ComponentProps> {
     /**
      * Creates a new instance of FileInput React component
      */


### PR DESCRIPTION
Hi, I was having trouble to import your library using typescript. I fixed it by extending React.Component. I hope this helps!
![image](https://user-images.githubusercontent.com/22083784/96059216-540ec900-0e5b-11eb-9abf-4cb2f686d908.png)
